### PR TITLE
Update read-json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "is-file": "^1.0.0",
     "minimist": "^1.1.0",
-    "read-json": "^0.1.0",
+    "read-json": "^1.0.0",
     "read-json-sync": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
There are no compatible version of `read-json` available on NPM. Need to update to 1.x or higher in order to have a compatible version
